### PR TITLE
updated checkForPwnage()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,14 +103,14 @@ async function checkForPwnage(password) {
   // range-search haveibeenpwned with the prefix
   const range = await fetch(
     `https://api.pwnedpasswords.com/range/${prefix}`
-  ).then(data => data.text());
+  ).then(data => data.text())
   
   // split the API results into an array and search for the suffix
-  const match = range.split('\r\n').find(r => r.includes(suffix));
+  const match = range.split('\r\n').find(r => r.includes(suffix))
   
   // if match is undefined return zero (no pwnage), 
   // otherwise spill the beans on how pwned it is
-  return !match ? 0 : +match.slice(36);
+  return !match ? 0 : +match.slice(36)
 }
 
 function isNumber(val) {


### PR DESCRIPTION
Did some synthetic testing and found that a custom binary search implementation with a couple of specific optimisations for this case was around 15% quicker than the existing function, but only about 1% quicker than Array.find() over a typical-sized response set from the API. 

I ended up going with Array.find() because the code is simpler/cleaner and threw in a few really puny optimisations (String.slice() is faster than String.substr(), things like this).